### PR TITLE
chore: update go, lint and gha

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,10 @@ jobs:
   Test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Set up Go
-        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version-file: 'go.mod'
 
@@ -30,6 +30,6 @@ jobs:
         run: make test
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
+        uses: codecov/codecov-action@54bcd8715eee62d40e33596ef5e8f0f48dbbccab # v4.1.0
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,14 +18,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Set up Go
-        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version-file: 'go.mod'
 
       - name: Run linters
-        uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299 # v3.6.0
+        uses: golangci/golangci-lint-action@3cfe3a4abbb849e10058ce4af15d205b6da42804 # v4.0.0
         with:
           version: latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,21 +13,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version-file: 'go.mod'
       - name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@72b6676b71ab476b77e676928516f6982eef7a41 # v5.3.0
+        uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4 # v6.1.0
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
       - name: Run goreleaser
-        uses: goreleaser/goreleaser-action@336e29918d653399e599bfca99fadc1d7ffbc9f7 # v4.3.0
+        uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
         with:
           distribution: goreleaser
           version: latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,7 @@ run:
   timeout: 10m
   concurrency: 4
   skip-dirs-use-default: false
+  tests: false
 
 linters:
   disable-all: true

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/thevilledev/vault-plugin-secrets-vercel
 
-go 1.20
+go 1.22
 
 require (
 	github.com/hashicorp/go-hclog v1.6.2

--- a/internal/plugin/backend.go
+++ b/internal/plugin/backend.go
@@ -8,11 +8,12 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
-// #nosec G101
 const (
+	// #nosec G101
 	backendSecretType = "vercel_token"
 	backendPathHelp   = `
 Vercel Secrets backend is a secrets backend for dynamically managing Vercel tokens.`
+	// #nosec G101
 	secretTokenIDDescription = `
 Token ID of the generated API key is stored in the plugin backend.
 This ID is used for revocation purposes. It can only be used to identify a key,

--- a/internal/plugin/backend_test.go
+++ b/internal/plugin/backend_test.go
@@ -30,7 +30,9 @@ func TestFactory(t *testing.T) {
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
+
 			ctx := context.Background()
+
 			b, err := Factory(ctx, tc.cfg)
 			if tc.expError != "" {
 				require.EqualError(t, err, tc.expError)

--- a/internal/plugin/path_config.go
+++ b/internal/plugin/path_config.go
@@ -190,7 +190,7 @@ func (b *backend) pathConfigDelete(ctx context.Context, req *logical.Request,
 }
 
 func (b *backend) pathConfigExistence() framework.ExistenceFunc {
-	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (bool, error) {
+	return func(ctx context.Context, req *logical.Request, _ *framework.FieldData) (bool, error) {
 		_, err := b.getConfig(ctx, req.Storage)
 
 		return err != nil, err

--- a/internal/plugin/path_config_test.go
+++ b/internal/plugin/path_config_test.go
@@ -187,7 +187,9 @@ func TestConfig_Write(t *testing.T) {
 				require.Nil(t, res)
 			} else {
 				require.NoError(t, err)
+
 				cfg, errg := b.getConfig(ctx, storage)
+
 				require.NoError(t, errg)
 				require.Equal(t, cfg, tc.expConfig)
 			}
@@ -251,7 +253,9 @@ func TestConfig_Delete(t *testing.T) {
 				require.Nil(t, res)
 			} else {
 				require.NoError(t, err)
+
 				res, errg := b.getConfig(ctx, storage)
+
 				require.NoError(t, errg)
 				require.Nil(t, res)
 			}

--- a/internal/plugin/path_info_test.go
+++ b/internal/plugin/path_info_test.go
@@ -36,7 +36,9 @@ func TestPathInfo(t *testing.T) {
 		require.NoError(t, err)
 
 		var vi version.Info
+
 		d, err := json.Marshal(res.Data)
+
 		require.NoError(t, err)
 		err = json.Unmarshal(d, &vi)
 		require.NoError(t, err)

--- a/internal/plugin/path_token_test.go
+++ b/internal/plugin/path_token_test.go
@@ -134,6 +134,7 @@ func TestToken_Create(t *testing.T) {
 				require.Nil(t, r)
 			} else {
 				require.Equal(t, r.Secret.LeaseOptions.TTL, defaultMaxTTL*time.Second)
+
 				for k, v := range tc.expDataFields {
 					require.Equal(t, r.Data[k], v)
 				}

--- a/internal/plugin/revoke_test.go
+++ b/internal/plugin/revoke_test.go
@@ -91,6 +91,7 @@ func TestToken_Revoke(t *testing.T) {
 					Data:      tc.tokenData,
 				})
 				require.NoError(t, err)
+
 				tokenID, _ = r.Data["token_id"].(string)
 			}
 


### PR DESCRIPTION
- update go version to 1.22
- update all github actions workflows to use latest versions (no more old node16 images)
- ignore test files from linting
- minor lint fixes